### PR TITLE
pagination fix

### DIFF
--- a/DocX/ParagraphElement.swift
+++ b/DocX/ParagraphElement.swift
@@ -34,7 +34,13 @@ class ParagraphElement:AEXMLElement{
         var elements=[AEXMLElement]()
         let subString=string.attributedSubstring(from: NSRange(range.range, in: string.string))
         
-        guard subString.length>0 else{return [AEXMLElement]()}
+        guard subString.length > 0 else {
+            if let breakElement=range.breakType.breakElement{
+                elements.append(breakElement)
+            }
+            return elements
+
+        }
         
         if let paragraphStyle=subString.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle{
             elements.append(paragraphStyle.paragraphElements)

--- a/DocXTests/DocXTests.swift
+++ b/DocXTests/DocXTests.swift
@@ -440,8 +440,25 @@ Specifies the border displayed above a set of paragraphs which have the same set
         
     }
     
-    @available(macOS 12, *)
     
+    @available(macOS 12, *)
+    func testAttributed2(){
+        var att=AttributedString("Lorem ipsum dolor sit amet")
+        att.font = NSFont(name: "Helvetica", size: 12)
+        att[att.range(of: "Lorem")!].backgroundColor = .blue
+        let title=String(att.characters.prefix(10))
+        let url=self.tempURL.appendingPathComponent(UUID().uuidString + "_myDocument_\(title)").appendingPathExtension("docx")
+        print(url.absoluteString)
+        do{
+            try att.writeDocX(to: url)
+        }
+        catch let error{
+            XCTFail(error.localizedDescription)
+        }
+        
+    }
+    
+    @available(macOS 12, *)
     func testMarkdown()throws{
         let mD="~~This~~ is a **Markdown** *string*."
         let att=try AttributedString(markdown: mD)

--- a/DocXTests/DocXTests.swift
+++ b/DocXTests/DocXTests.swift
@@ -319,11 +319,14 @@ Specifies the border displayed above a set of paragraphs which have the same set
     }
     
     func testMultiPageWriter() {
-        
+        // added parahraph breaks at the end to catch a bug reported by andalman
+        //https://github.com/shinjukunian/DocX/issues/14
         let string =
         """
 This property contains the space (measured in points) added at the end of the paragraph to separate it from the following paragraph. This value is always nonnegative. The space between paragraphs is determined by adding the previous paragraph’s paragraphSpacing and the current paragraph’s paragraphSpacingBefore.
 Specifies the border displayed above a set of paragraphs which have the same set of paragraph border settings. Note that if the adjoining paragraph has identical border settings and a between border is specified, a single between border will be used instead of the bottom border for the first and a top border for the second.
+
+
 """
         
        


### PR DESCRIPTION
fixes #14 (pagination fails when there are paragraph breaks at the end of the attributed string)