### PR TITLE
Allow replacing existing docx files

### DIFF
--- a/DocX/NSAttributedString+Writing.swift
+++ b/DocX/NSAttributedString+Writing.swift
@@ -47,7 +47,17 @@ extension NSAttributedString{
 
         let zipURL=tempURL.appendingPathComponent(UUID().uuidString).appendingPathExtension("zip")
         try FileManager.default.zipItem(at: docURL, to: zipURL, shouldKeepParent: false, compressionMethod: .deflate, progress: nil)
-
-        try FileManager.default.copyItem(at: zipURL, to: url)
+        
+        // Attempt to copy the docx file to its final destination
+        // We expect this will fail if a file already exists there
+        do {
+            try FileManager.default.copyItem(at: zipURL, to: url)
+        } catch {
+            // If the copy failed, attempt to replace the file
+            let _ = try FileManager.default.replaceItemAt(url,
+                                                          withItemAt: zipURL,
+                                                          backupItemName: nil,
+                                                          options: .usingNewMetadataOnly)
+        }
     }
 }


### PR DESCRIPTION
When writing a docx file, `writeDocX_builtin()` uses `copyItem` to copy the docx file to its final destination. This can fail if there is another file at that location. If that happens, attempt to replace that file using `replaceItemAt`.

https://github.com/shinjukunian/DocX/issues/20