### PR TITLE
Fix for Issue #22 - Speeding up writing for very long, mulit-page strings

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcbaselines/DocXTests.xcbaseline/15F8C2FB-435F-4ED7-B9DA-5B95E8F66DAB.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/DocXTests.xcbaseline/15F8C2FB-435F-4ED7-B9DA-5B95E8F66DAB.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>108.449908</real>
+					<real>1.160000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -21,7 +21,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>1.223787</real>
+					<real>1.180000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/DocXTests.xcbaseline/15F8C2FB-435F-4ED7-B9DA-5B95E8F66DAB.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/DocXTests.xcbaseline/15F8C2FB-435F-4ED7-B9DA-5B95E8F66DAB.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>DocXTests</key>
+		<dict>
+			<key>testPerformanceLongBook()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>108.449908</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPerformanceLongString()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>1.223787</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/.swiftpm/xcode/xcshareddata/xcbaselines/DocXTests.xcbaseline/Info.plist
+++ b/.swiftpm/xcode/xcshareddata/xcbaselines/DocXTests.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>15F8C2FB-435F-4ED7-B9DA-5B95E8F66DAB</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>0</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Apple M1 Pro</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>0</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>modelCode</key>
+				<string>MacBookPro18,3</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>10</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>arm64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/DocX/ParagraphElement.swift
+++ b/DocX/ParagraphElement.swift
@@ -32,7 +32,7 @@ class ParagraphElement:AEXMLElement{
     fileprivate func buildRuns(string:NSAttributedString, range:NSAttributedString.ParagraphRange)->[AEXMLElement]{
         
         var elements=[AEXMLElement]()
-        let subString=string.attributedSubstring(from: NSRange(range.range, in: string.string))
+        let subString=string.attributedSubstring(from: range.range)
         
         guard subString.length > 0 else {
             if let breakElement=range.breakType.breakElement{

--- a/DocXTests/DocXTests.swift
+++ b/DocXTests/DocXTests.swift
@@ -496,6 +496,48 @@ And this is a [link](http://www.example.com).
         att[att.range(of: "This")!].foregroundColor = .red
         try writeAndValidateDocX(attributedString: NSAttributedString(att))
     }
+    
+    // MARK: Performance Tests
+    
+    func testPerformanceLongBook() {
+        // Two paragraphs / 100 words
+        let twoParagraphs =
+"""
+This property contains the space (measured in points) added at the end of the paragraph to separate it from the following paragraph. This value is always nonnegative. The space between paragraphs is determined by adding the previous paragraph’s paragraphSpacing and the current paragraph’s paragraphSpacingBefore.
+Specifies the border displayed above a set of paragraphs which have the same set of paragraph border settings. Note that if the adjoining paragraph has identical border settings and a between border is specified, a single between border will be used instead of the bottom border for the first and a top border for the second.
+"""
+        // Create a "book" that consists of 400 chapters each with 5,000 words
+        // (2 million words total)
+        let chapterString = String(repeating: twoParagraphs, count: 50)
+        let chapterAttributedString = NSAttributedString(string: chapterString)
+        let chapters = Array(repeating: chapterAttributedString, count: 400)
+        
+        let basename = docxBasename(attributedString:chapterAttributedString)
+        let url = self.tempURL.appendingPathComponent(basename).appendingPathExtension("docx")
+        
+        measure {
+            try? DocXWriter.write(pages: chapters, to: url)
+        }
+    }
+    
+    func testPerformanceLongString() throws {
+        // Two paragraphs / 100 words
+        let twoParagraphs =
+"""
+This property contains the space (measured in points) added at the end of the paragraph to separate it from the following paragraph. This value is always nonnegative. The space between paragraphs is determined by adding the previous paragraph’s paragraphSpacing and the current paragraph’s paragraphSpacingBefore.
+Specifies the border displayed above a set of paragraphs which have the same set of paragraph border settings. Note that if the adjoining paragraph has identical border settings and a between border is specified, a single between border will be used instead of the bottom border for the first and a top border for the second.
+"""
+        // Create a string that consists of 40,000 paragraphs
+        // (2 million words total)
+        let longString = String(repeating: twoParagraphs, count: 20_000)
+        let longAttributedString = NSAttributedString(string: longString)
+        
+        let basename = docxBasename(attributedString:longAttributedString)
+        let url = self.tempURL.appendingPathComponent(basename).appendingPathExtension("docx")
+        measure {
+            try? longAttributedString.writeDocX(to: url)
+        }
+    }
 }
 
 #endif


### PR DESCRIPTION
The first commit simply adds two performance tests, one of which has a baseline of ~100s(!).

The second commit is the fix, and updates the baselines for these performance tests. That fix adjusts the baseline for the test that took nearly *2 minutes* down to a little over *1 second*.