### PR TITLE
Turn on XML escaping in the document.xml.rels file

### DIFF
--- a/DocX/NSAttributedString+DocX-macOS.swift
+++ b/DocX/NSAttributedString+DocX-macOS.swift
@@ -49,6 +49,12 @@ extension NSAttributedString{
             var options=AEXMLOptions()
             options.parserSettings.shouldTrimWhitespace=false
             options.documentHeader.standalone="yes"
+            
+            // Enable escaping so that reserved characters, like < & >, don't
+            // result in an invalid docx file
+            // See: https://github.com/shinjukunian/DocX/issues/24
+            options.escape = true
+
             let linkDocument=try AEXMLDocument(xml: linkData, options: options)
             let linkRelations=self.prepareLinks(linkXML: linkDocument, mediaURL: mediaURL)
             let updatedLinks=linkDocument.xmlCompact

--- a/DocX/NSAttributedString+Writing.swift
+++ b/DocX/NSAttributedString+Writing.swift
@@ -33,6 +33,12 @@ extension NSAttributedString{
         var docOptions=AEXMLOptions()
         docOptions.parserSettings.shouldTrimWhitespace=false
         docOptions.documentHeader.standalone="yes"
+        
+        // Enable escaping so that reserved characters, like < & >, don't
+        // result in an invalid docx file
+        // See: https://github.com/shinjukunian/DocX/issues/24
+        docOptions.escape = true
+        
         let linkDocument=try AEXMLDocument(xml: linkData, options: docOptions)
         let linkRelations=self.prepareLinks(linkXML: linkDocument, mediaURL: mediaURL)
         let updatedLinks=linkDocument.xmlCompact


### PR DESCRIPTION
This will properly escape reserved characters that appear in links (e.g. the ampersand)

https://github.com/shinjukunian/DocX/issues/24