### PR TITLE
Image scale to fit

### DIFF
--- a/DocX/DocX.swift
+++ b/DocX/DocX.swift
@@ -29,7 +29,7 @@ protocol DocX{
                       options:DocXOptions) throws ->String
     func writeDocX(to url:URL)throws
     func writeDocX(to url:URL, options:DocXOptions) throws
-    func prepareLinks(linkXML:AEXMLDocument, mediaURL:URL)->[DocumentRelationship]
+    func prepareLinks(linkXML:AEXMLDocument, mediaURL:URL, options:DocXOptions)->[DocumentRelationship]
 }
 
 public let docXUTIType="org.openxmlformats.wordprocessingml.document"

--- a/DocX/DocXOptions.swift
+++ b/DocX/DocXOptions.swift
@@ -42,7 +42,7 @@ public struct DocXOptions{
     /// An optional configuration object for style output
     public var styleConfiguration: DocXStyleConfiguration?
     
-    /// An optional parameter that specifies the page (paper) size and margins. If not specified (`nil`) Word will use default values based on the current locale and printer settings. The default value is `nil`.
+    /// An optional parameter that specifies the page (paper) size and margins. If not specified (`nil`), Word will use default values based on the current locale and printer settings. The default value is `nil`.
     public var pageDefinition: PageDefinition?
     
     public init(){}

--- a/DocX/DocXOptions.swift
+++ b/DocX/DocXOptions.swift
@@ -42,6 +42,8 @@ public struct DocXOptions{
     /// An optional configuration object for style output
     public var styleConfiguration: DocXStyleConfiguration?
     
+    /// An optional parameter that specifies the page (paper) size and margins. If not specified (`nil`) Word will use default values based on the current locale and printer settings. The default value is `nil`.
+    public var pageDefinition: PageDefinition?
     
     public init(){}
     

--- a/DocX/DocXPageDefinition.swift
+++ b/DocX/DocXPageDefinition.swift
@@ -15,26 +15,20 @@ fileprivate typealias NSEdgeInsets = UIEdgeInsets
 #endif
 
 public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
-    
+        
     /// The size of a page
     public struct PageSize:Equatable, CustomStringConvertible, Hashable{
         
         ///Page width in twips
-        let width:Int
+        let width:Measurement<UnitLength>
         
         /// Page height in twips
-        let height:Int
-        
-        /// Memberwise initializer, width and height are in twips (point / 20)
-        init(width: Int, height: Int) {
-            self.width = width
-            self.height = height
-        }
+        let height:Measurement<UnitLength>
         
         /// Convenience initializer using a `CGSize`. All values are in points.
         public init(size:CGSize){
-            self.width = Int(Measurement(value: size.width, unit: UnitLength.points).converted(to: .twips).value)
-            self.height = Int(Measurement(value: size.height, unit: UnitLength.points).converted(to: .twips).value)
+            self.width = Measurement(value: size.width, unit: UnitLength.points)
+            self.height = Measurement(value: size.height, unit: UnitLength.points)
         }
         
         /// Convenience initializer to define the page size in length units (mm, cm, inches)
@@ -50,23 +44,25 @@ public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
         /// let page=PageSize(width: width, height: height)
         /// ```
         public init(width:Measurement<UnitLength>, height: Measurement<UnitLength>){
-            self.width = Int(width.converted(to: .twips).value)
-            self.height = Int(height.converted(to: .twips).value)
+            self.width = width
+            self.height = height
         }
         
         public var description: String{
             let formatter=MeasurementFormatter()
             formatter.unitOptions = [.providedUnit]
-            return "Width: \(formatter.string(from: Measurement(value: Double(width), unit: UnitLength.twips).converted(to: .points))), height: \(formatter.string(from: Measurement(value: Double(height), unit: UnitLength.twips).converted(to: .points)))\rWidth: \(formatter.string(from: Measurement(value: Double(width), unit: UnitLength.twips).converted(to: UnitLength.centimeters))), height: \(formatter.string(from: Measurement(value: Double(height), unit: UnitLength.twips).converted(to: UnitLength.centimeters)))"
+            return "Width: \(formatter.string(from: width.converted(to: .points))), height: \(formatter.string(from: height.converted(to: .points)))\rWidth: \(formatter.string(from: width.converted(to: UnitLength.centimeters))), height: \(formatter.string(from: height.converted(to: UnitLength.centimeters)))"
         }
         
         /// An A4 page
-        public static let A4:PageSize = PageSize(size: .init(width: CGFloat(595), height: 842))
+        public static let A4:PageSize = PageSize(size: .init(width: 595, height: 842))
         
         /// A Letter page
-        public static let letter:PageSize = PageSize(size: .init(width: CGFloat(612), height: 792))
+        public static let letter:PageSize = PageSize(size: .init(width: 612, height: 792))
         
         var pageSizeElement:AEXMLElement{
+            let width=Int(width.converted(to: .twips).value)
+            let height=Int(height.converted(to: .twips).value)
             return AEXMLElement(name: "w:pgSz", value: nil, attributes: ["w:w":String(width), "w:h":String(height), "w:orient":"landscape"])
         }
         
@@ -77,7 +73,7 @@ public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
         
         /// The size of the page in in a desired unit of length (cm, mm, inches, etc.)
         public func size(unit:UnitLength)->CGSize{
-            return CGSize(width: Measurement(value: Double(width), unit: UnitLength.twips).converted(to: unit).value, height: Measurement(value: Double(width), unit: UnitLength.twips).converted(to: unit).value)
+            return CGSize(width: width.converted(to: unit).value, height: height.converted(to: unit).value)
         }
     }
     
@@ -85,41 +81,25 @@ public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
     public struct PageMargins:Equatable, CustomStringConvertible, Hashable{
         
         /// Top margin in twips
-        let top:Int
+        let top:Measurement<UnitLength>
         
         /// bottom margin in twips.
-        let bottom:Int
+        let bottom:Measurement<UnitLength>
         
         /// left margin in twips
-        let left:Int
+        let left:Measurement<UnitLength>
         
         /// right margin in twips
-        let right:Int
+        let right:Measurement<UnitLength>
         
         /// footer margin in twips. The larger value of `bottom` or `footer` will be used
-        let footer:Int
+        let footer:Measurement<UnitLength>
         
         /// header margin in twips. The larger value of `header` and `top` will be used.
-        let header:Int
+        let header:Measurement<UnitLength>
         
-        /// memberwise initializer. All values are in twips (twentieth of an inch)
-        /// - Parameters:
-        ///     - top: top margin
-        ///     - bottom: bottom margin
-        ///     - left: left margin
-        ///     - right: right margin
-        ///     - footer: footer margin
-        ///     - header: header margin
-        init(top: Int, bottom: Int, left: Int, right: Int, footer: Int=0, header: Int=0) {
-            self.top = top
-            self.bottom = bottom
-            self.left = left
-            self.right = right
-            self.footer = footer
-            self.header = header
-        }
         
-        /// memberwise initializer. All values are in points. One inch (2.54 cm) is 72 points.
+        /// Convenience initializer. All values are in points. One inch (2.54 cm) is 72 points.
         /// - Parameters:
         ///     - top: top margin
         ///     - bottom: bottom margin
@@ -128,22 +108,29 @@ public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
         ///     - footer: footer margin
         ///     - header: header margin
         public init(top:CGFloat, bottom: CGFloat, left: CGFloat, right: CGFloat, footer: CGFloat = 0, header: CGFloat = 0) {
-            self.top = Int(Measurement(value: top, unit: UnitLength.points).converted(to: .twips).value)
-            self.bottom = Int(Measurement(value: bottom, unit: UnitLength.points).converted(to: .twips).value)
-            self.left = Int(Measurement(value: left, unit: UnitLength.points).converted(to: .twips).value)
-            self.right = Int(Measurement(value: right, unit: UnitLength.points).converted(to: .twips).value)
-            self.footer = Int(Measurement(value: footer, unit: UnitLength.points).converted(to: .twips).value)
-            self.header = Int(Measurement(value: header, unit: UnitLength.points).converted(to: .twips).value)
+            self.top = Measurement(value: top, unit: UnitLength.points)
+            self.bottom = Measurement(value: bottom, unit: UnitLength.points)
+            self.left = Measurement(value: left, unit: UnitLength.points)
+            self.right = Measurement(value: right, unit: UnitLength.points)
+            self.footer = Measurement(value: footer, unit: UnitLength.points)
+            self.header = Measurement(value: header, unit: UnitLength.points)
         }
         
-        /// Convenience initializer to define the margins size in length units (mm, cm, inches)
+        /// Memberwise initializer to define the margins size in length units (mm, cm, inches)
+        /// - Parameters:
+        ///     - top: top margin
+        ///     - bottom: bottom margin
+        ///     - left: left margin
+        ///     - right: right margin
+        ///     - footer: footer margin
+        ///     - header: header margin
         public init(top:Measurement<UnitLength>, bottom: Measurement<UnitLength>, left: Measurement<UnitLength>, right: Measurement<UnitLength>, footer: Measurement<UnitLength> = Measurement(value: 0, unit: .centimeters), header: Measurement<UnitLength> = Measurement(value: 0, unit: .centimeters)){
-            self.top = Int(top.converted(to: .twips).value)
-            self.bottom = Int(bottom.converted(to: .twips).value)
-            self.left = Int(left.converted(to: .twips).value)
-            self.right = Int(right.converted(to: .twips).value)
-            self.footer = Int(footer.converted(to: .twips).value)
-            self.header = Int(header.converted(to: .twips).value)
+            self.top = top
+            self.bottom = bottom
+            self.left = left
+            self.right = right
+            self.footer = footer
+            self.header = header
         }
         
 #if os(macOS)
@@ -165,22 +152,22 @@ public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
         
         /// Effective margins of the page in a unit of length.
         public func effectiveMargins(unit:UnitLength)->NSEdgeInsets{
-            let top = top < 0 ? top : max(top, header)
-            let bottom = bottom < 0 ? bottom : max(bottom, footer)
-            return NSEdgeInsets(top: Measurement(value: Double(top), unit: UnitLength.twips).converted(to: unit).value, left: Measurement(value: Double(left), unit: UnitLength.twips).converted(to: unit).value, bottom: Measurement(value: Double(bottom), unit: UnitLength.twips).converted(to: unit).value, right: Measurement(value: Double(right), unit: UnitLength.twips).converted(to: unit).value)
+            let top = top < Measurement(value: 0, unit: .points) ? top : max(top, header)
+            let bottom = bottom < Measurement(value: 0, unit: .points) ? bottom : max(bottom, footer)
+            return NSEdgeInsets(top: top.converted(to: unit).value, left: left.converted(to: unit).value, bottom: bottom.converted(to: unit).value, right: right.converted(to: unit).value)
         }
         
         public var description: String{
             let formatter=MeasurementFormatter()
             formatter.unitOptions = [.providedUnit]
-            return "Top \(formatter.string(from: Measurement(value: Double(top), unit: UnitLength.twips).converted(to: .points))), bottom: \(formatter.string(from: Measurement(value: Double(bottom), unit: UnitLength.twips).converted(to: .points))), left: \(formatter.string(from: Measurement(value: Double(left), unit: UnitLength.twips).converted(to: .points))), right: \(formatter.string(from: Measurement(value: Double(right), unit: UnitLength.twips).converted(to: .points))), footer: \(formatter.string(from: Measurement(value: Double(footer), unit: UnitLength.twips).converted(to: .points))), header: \(formatter.string(from: Measurement(value: Double(header), unit: UnitLength.twips).converted(to: .points)))\rTop \(formatter.string(from: Measurement(value: Double(top), unit: UnitLength.twips).converted(to: .centimeters))), bottom: \(formatter.string(from: Measurement(value: Double(bottom), unit: UnitLength.twips).converted(to: .centimeters))), left: \(formatter.string(from: Measurement(value: Double(left), unit: UnitLength.twips).converted(to: .centimeters))), right: \(formatter.string(from: Measurement(value: Double(right), unit: UnitLength.twips).converted(to: .centimeters))), footer: \(formatter.string(from: Measurement(value: Double(footer), unit: UnitLength.twips).converted(to: .centimeters))), header: \(formatter.string(from: Measurement(value: Double(header), unit: UnitLength.twips).converted(to: .centimeters)))"
+            return "Top \(formatter.string(from: top.converted(to: .points))), bottom: \(formatter.string(from: bottom.converted(to: .points))), left: \(formatter.string(from: left.converted(to: .points))), right: \(formatter.string(from: right.converted(to: .points))), footer: \(formatter.string(from: footer.converted(to: .points))), header: \(formatter.string(from: header.converted(to: .points)))\rTop \(formatter.string(from: top.converted(to: .centimeters))), bottom: \(formatter.string(from: bottom.converted(to: .centimeters))), left: \(formatter.string(from: left.converted(to: .centimeters))), right: \(formatter.string(from: right.converted(to: .centimeters))), footer: \(formatter.string(from: footer.converted(to: .centimeters))), header: \(formatter.string(from: header.converted(to: .centimeters)))"
         }
         
-        /// The default margins if a standard Word document.
+        /// The default margins of a standard Word document (one inch).
         public static let `default` = PageMargins(top: CGFloat(72), bottom: 72, left: 72, right: 72, footer: 35.4, header: 35.4)
         
         var marginElement:AEXMLElement{
-            return AEXMLElement(name: "w:pgMar", value: nil, attributes: ["w:top":String(top), "w:right":String(right), "w:bottom":String(bottom), "w:left":String(left), "w:header":String(header), "w:footer":String(footer), "w:gutter":"0"])
+            return AEXMLElement(name: "w:pgMar", value: nil, attributes: ["w:top":String(Int(top.converted(to: .twips).value)), "w:right":String(Int(right.converted(to: .twips).value)), "w:bottom":String(Int(bottom.converted(to: .twips).value)), "w:left":String(Int(left.converted(to: .twips).value)), "w:header":String(Int(header.converted(to: .twips).value)), "w:footer":String(Int(footer.converted(to: .twips).value)), "w:gutter":"0"])
         }
     }
     
@@ -194,6 +181,7 @@ public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
         return "Paper Size: \(pageSize),\r\rMargins: \(pageMargins)"
     }
     
+   
     /// Initializes a page Definition with a page (paper) size and margins
     /// - Parameters:
     ///     - pageSize: a page (paper) size, e.g. A4.
@@ -221,11 +209,11 @@ public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
 
 public extension UnitLength{
     class var points:UnitLength{
-        return UnitLength(symbol: "points", converter: UnitConverterLinear(coefficient: 1/100 / 28.3465))
+        return UnitLength(symbol: "points", converter: UnitConverterLinear(coefficient: 1/100 / 72 * 2.54))
     }
     
     class var twips:UnitLength{
-        return UnitLength(symbol: "twips", converter: UnitConverterLinear(coefficient: 1/100 / 28.3465 / 20))
+        return UnitLength(symbol: "twips", converter: UnitConverterLinear(coefficient: 1/100 / 72 * 2.54 / 20))
     }
 }
 

--- a/DocX/DocXPageDefinition.swift
+++ b/DocX/DocXPageDefinition.swift
@@ -1,0 +1,231 @@
+//
+//  DocXPageDefinition.swift
+//  
+//
+//  Created by Morten Bertz on 2023/01/13.
+//
+
+import CoreGraphics
+import Foundation
+import AEXML
+
+#if canImport(UIKit)
+import UIKit
+fileprivate typealias NSEdgeInsets = UIEdgeInsets
+#endif
+
+public struct PageDefinition: Equatable, CustomStringConvertible, Hashable{
+    
+    /// The size of a page
+    public struct PageSize:Equatable, CustomStringConvertible, Hashable{
+        
+        ///Page width in twips
+        let width:Int
+        
+        /// Page height in twips
+        let height:Int
+        
+        /// Memberwise initializer, width and height are in twips (point / 20)
+        init(width: Int, height: Int) {
+            self.width = width
+            self.height = height
+        }
+        
+        /// Convenience initializer using a `CGSize`. All values are in points.
+        public init(size:CGSize){
+            self.width = Int(Measurement(value: size.width, unit: UnitLength.points).converted(to: .twips).value)
+            self.height = Int(Measurement(value: size.height, unit: UnitLength.points).converted(to: .twips).value)
+        }
+        
+        /// Convenience initializer to define the page size in length units (mm, cm, inches)
+        /// - Parameters:
+        ///     - width: the width if the page as a length measurement
+        ///     - height: the width if the page as a length measurement
+        /// Discussion:
+        ///
+        /// For an A4 page (21 cm x 29.7 cm), use
+        /// ```
+        /// let width=Measurement(value: 21, unit: UnitLength.centimeters)
+        /// let height=Measurement(value: 29.7, unit: UnitLength.centimeters)
+        /// let page=PageSize(width: width, height: height)
+        /// ```
+        public init(width:Measurement<UnitLength>, height: Measurement<UnitLength>){
+            self.width = Int(width.converted(to: .twips).value)
+            self.height = Int(height.converted(to: .twips).value)
+        }
+        
+        public var description: String{
+            let formatter=MeasurementFormatter()
+            formatter.unitOptions = [.providedUnit]
+            return "Width: \(formatter.string(from: Measurement(value: Double(width), unit: UnitLength.twips).converted(to: .points))), height: \(formatter.string(from: Measurement(value: Double(height), unit: UnitLength.twips).converted(to: .points)))\rWidth: \(formatter.string(from: Measurement(value: Double(width), unit: UnitLength.twips).converted(to: UnitLength.centimeters))), height: \(formatter.string(from: Measurement(value: Double(height), unit: UnitLength.twips).converted(to: UnitLength.centimeters)))"
+        }
+        
+        /// An A4 page
+        public static let A4:PageSize = PageSize(size: .init(width: CGFloat(595), height: 842))
+        
+        /// A Letter page
+        public static let letter:PageSize = PageSize(size: .init(width: CGFloat(612), height: 792))
+        
+        var pageSizeElement:AEXMLElement{
+            return AEXMLElement(name: "w:pgSz", value: nil, attributes: ["w:w":String(width), "w:h":String(height), "w:orient":"landscape"])
+        }
+        
+        /// The size of the page in points
+        public var cgSize:CGSize{
+            return size(unit: .points)
+        }
+        
+        /// The size of the page in in a desired unit of length (cm, mm, inches, etc.)
+        public func size(unit:UnitLength)->CGSize{
+            return CGSize(width: Measurement(value: Double(width), unit: UnitLength.twips).converted(to: unit).value, height: Measurement(value: Double(width), unit: UnitLength.twips).converted(to: unit).value)
+        }
+    }
+    
+    /// The margins of a page (insets of the printable area).
+    public struct PageMargins:Equatable, CustomStringConvertible, Hashable{
+        
+        /// Top margin in twips
+        let top:Int
+        
+        /// bottom margin in twips.
+        let bottom:Int
+        
+        /// left margin in twips
+        let left:Int
+        
+        /// right margin in twips
+        let right:Int
+        
+        /// footer margin in twips. The larger value of `bottom` or `footer` will be used
+        let footer:Int
+        
+        /// header margin in twips. The larger value of `header` and `top` will be used.
+        let header:Int
+        
+        /// memberwise initializer. All values are in twips (twentieth of an inch)
+        /// - Parameters:
+        ///     - top: top margin
+        ///     - bottom: bottom margin
+        ///     - left: left margin
+        ///     - right: right margin
+        ///     - footer: footer margin
+        ///     - header: header margin
+        init(top: Int, bottom: Int, left: Int, right: Int, footer: Int=0, header: Int=0) {
+            self.top = top
+            self.bottom = bottom
+            self.left = left
+            self.right = right
+            self.footer = footer
+            self.header = header
+        }
+        
+        /// memberwise initializer. All values are in points. One inch (2.54 cm) is 72 points.
+        /// - Parameters:
+        ///     - top: top margin
+        ///     - bottom: bottom margin
+        ///     - left: left margin
+        ///     - right: right margin
+        ///     - footer: footer margin
+        ///     - header: header margin
+        public init(top:CGFloat, bottom: CGFloat, left: CGFloat, right: CGFloat, footer: CGFloat = 0, header: CGFloat = 0) {
+            self.top = Int(Measurement(value: top, unit: UnitLength.points).converted(to: .twips).value)
+            self.bottom = Int(Measurement(value: bottom, unit: UnitLength.points).converted(to: .twips).value)
+            self.left = Int(Measurement(value: left, unit: UnitLength.points).converted(to: .twips).value)
+            self.right = Int(Measurement(value: right, unit: UnitLength.points).converted(to: .twips).value)
+            self.footer = Int(Measurement(value: footer, unit: UnitLength.points).converted(to: .twips).value)
+            self.header = Int(Measurement(value: header, unit: UnitLength.points).converted(to: .twips).value)
+        }
+        
+        /// Convenience initializer to define the margins size in length units (mm, cm, inches)
+        public init(top:Measurement<UnitLength>, bottom: Measurement<UnitLength>, left: Measurement<UnitLength>, right: Measurement<UnitLength>, footer: Measurement<UnitLength> = Measurement(value: 0, unit: .centimeters), header: Measurement<UnitLength> = Measurement(value: 0, unit: .centimeters)){
+            self.top = Int(top.converted(to: .twips).value)
+            self.bottom = Int(bottom.converted(to: .twips).value)
+            self.left = Int(left.converted(to: .twips).value)
+            self.right = Int(right.converted(to: .twips).value)
+            self.footer = Int(footer.converted(to: .twips).value)
+            self.header = Int(header.converted(to: .twips).value)
+        }
+        
+#if os(macOS)
+        /// Convenience initializer. Edge insets are in points.
+        public init(edgeInsets:NSEdgeInsets){
+            self.init(top: edgeInsets.top, bottom: edgeInsets.bottom, left: edgeInsets.left, right: edgeInsets.right)
+        }
+        
+#elseif os(iOS)
+        /// Convenience initializer. Edge insets are in points.
+        public init(edgeInsets:UIEdgeInsets){
+            self.init(top: edgeInsets.top, bottom: edgeInsets.bottom, left: edgeInsets.left, right: edgeInsets.right)
+        }
+        
+#endif
+        fileprivate var effectiveMargins:NSEdgeInsets{
+            return effectiveMargins(unit: .points)
+        }
+        
+        /// Effective margins of the page in a unit of length.
+        public func effectiveMargins(unit:UnitLength)->NSEdgeInsets{
+            let top = top < 0 ? top : max(top, header)
+            let bottom = bottom < 0 ? bottom : max(bottom, footer)
+            return NSEdgeInsets(top: Measurement(value: Double(top), unit: UnitLength.twips).converted(to: unit).value, left: Measurement(value: Double(left), unit: UnitLength.twips).converted(to: unit).value, bottom: Measurement(value: Double(bottom), unit: UnitLength.twips).converted(to: unit).value, right: Measurement(value: Double(right), unit: UnitLength.twips).converted(to: unit).value)
+        }
+        
+        public var description: String{
+            let formatter=MeasurementFormatter()
+            formatter.unitOptions = [.providedUnit]
+            return "Top \(formatter.string(from: Measurement(value: Double(top), unit: UnitLength.twips).converted(to: .points))), bottom: \(formatter.string(from: Measurement(value: Double(bottom), unit: UnitLength.twips).converted(to: .points))), left: \(formatter.string(from: Measurement(value: Double(left), unit: UnitLength.twips).converted(to: .points))), right: \(formatter.string(from: Measurement(value: Double(right), unit: UnitLength.twips).converted(to: .points))), footer: \(formatter.string(from: Measurement(value: Double(footer), unit: UnitLength.twips).converted(to: .points))), header: \(formatter.string(from: Measurement(value: Double(header), unit: UnitLength.twips).converted(to: .points)))\rTop \(formatter.string(from: Measurement(value: Double(top), unit: UnitLength.twips).converted(to: .centimeters))), bottom: \(formatter.string(from: Measurement(value: Double(bottom), unit: UnitLength.twips).converted(to: .centimeters))), left: \(formatter.string(from: Measurement(value: Double(left), unit: UnitLength.twips).converted(to: .centimeters))), right: \(formatter.string(from: Measurement(value: Double(right), unit: UnitLength.twips).converted(to: .centimeters))), footer: \(formatter.string(from: Measurement(value: Double(footer), unit: UnitLength.twips).converted(to: .centimeters))), header: \(formatter.string(from: Measurement(value: Double(header), unit: UnitLength.twips).converted(to: .centimeters)))"
+        }
+        
+        /// The default margins if a standard Word document.
+        public static let `default` = PageMargins(top: CGFloat(72), bottom: 72, left: 72, right: 72, footer: 35.4, header: 35.4)
+        
+        var marginElement:AEXMLElement{
+            return AEXMLElement(name: "w:pgMar", value: nil, attributes: ["w:top":String(top), "w:right":String(right), "w:bottom":String(bottom), "w:left":String(left), "w:header":String(header), "w:footer":String(footer), "w:gutter":"0"])
+        }
+    }
+    
+    /// The page size of the document
+    let pageSize:PageSize
+    
+    /// The page margins of the document
+    let pageMargins:PageMargins
+    
+    public var description: String{
+        return "Paper Size: \(pageSize),\r\rMargins: \(pageMargins)"
+    }
+    
+    /// Initializes a page Definition with a page (paper) size and margins
+    /// - Parameters:
+    ///     - pageSize: a page (paper) size, e.g. A4.
+    ///     - pageMargins: the margins from the edge of the page to the borders of the printed text.
+    public init(pageSize: PageSize, pageMargins: PageMargins = .default) {
+        self.pageSize = pageSize
+        self.pageMargins = pageMargins
+    }
+    
+   
+    /// The effective printable area of the page in a unit of length.
+    public func printableSize(unit: UnitLength = .points) ->CGSize{
+        let size=self.pageSize.size(unit: unit)
+        let margins=self.pageMargins.effectiveMargins(unit: unit)
+        return CGSize(width: size.width - margins.right - margins.left, height: size.height - margins.bottom - margins.top)
+    }
+    
+    
+    var pageElements:[AEXMLElement]{
+        return [pageSize.pageSizeElement, pageMargins.marginElement]
+    }
+    
+}
+
+
+public extension UnitLength{
+    class var points:UnitLength{
+        return UnitLength(symbol: "points", converter: UnitConverterLinear(coefficient: 1/100 / 28.3465))
+    }
+    
+    class var twips:UnitLength{
+        return UnitLength(symbol: "twips", converter: UnitConverterLinear(coefficient: 1/100 / 28.3465 / 20))
+    }
+}
+

--- a/DocX/DocXWriter.swift
+++ b/DocX/DocXWriter.swift
@@ -12,9 +12,8 @@ public class DocXWriter{
     /// Convenience function to write an array of NSAttributedString to separate pages in a .docx file
     /// - Parameters:
     ///   - pages: an array of NSAttributedStrings. A page break fill be inserted after each page.
-    ///   - url: The destination of the resulting .docx, e.g. ```myfile.docx```
-    ///   - options: an optional instance of `DocXOptions`. This allows you to specify metadata for the document.
-    ///   - configuration: an optional instance of `DocXConfiguration` that allows you to control the docx output.
+    ///   - url: The destination of the resulting .docx, e.g. `myfile.docx`
+    ///   - options: an optional instance of `DocXOptions`. This allows you to specify metadata for the document and customize docx output.
     /// - Throws: Throws errors for I/O.
     public class func write(pages:[NSAttributedString],
                             to url:URL,

--- a/DocX/DocXWriting.swift
+++ b/DocX/DocXWriting.swift
@@ -97,10 +97,10 @@ extension DocX where Self : NSAttributedString{
         return lastIdIDX
     }
    
-    func prepareLinks(linkXML: AEXMLDocument, mediaURL:URL) -> [DocumentRelationship] {
+    func prepareLinks(linkXML: AEXMLDocument, mediaURL:URL, options:DocXOptions) -> [DocumentRelationship] {
         var linkURLS=[URL]()
         
-        let imageRelationships = prepareImages(linkXML: linkXML, mediaURL:mediaURL)
+        let imageRelationships = prepareImages(linkXML: linkXML, mediaURL:mediaURL, options: options)
         
         self.enumerateAttribute(.link, in: NSRange(location: 0, length: self.length), options: [.longestEffectiveRangeNotRequired], using: {attribute, _, stop in
             if let link=attribute as? URL{
@@ -124,7 +124,7 @@ extension DocX where Self : NSAttributedString{
         return linkRelationShips + imageRelationships
     }
     
-    func prepareImages(linkXML: AEXMLDocument, mediaURL:URL) -> [DocumentRelationship]{
+    func prepareImages(linkXML: AEXMLDocument, mediaURL:URL, options:DocXOptions) -> [DocumentRelationship]{
         var attachements=[NSTextAttachment]()
         self.enumerateAttribute(.attachment, in: NSRange(location: 0, length: self.length), options: [.longestEffectiveRangeNotRequired], using: {attribute, _, stop in
             if let link=attribute as? NSTextAttachment{
@@ -173,7 +173,7 @@ extension DocX where Self : NSAttributedString{
                 return nil
             }
 
-            let relationShip=ImageRelationship(relationshipID: newID, linkURL: destURL, attachement: attachement)
+            let relationShip=ImageRelationship(relationshipID: newID, linkURL: destURL, attachement: attachement, pageDefinition: options.pageDefinition)
             return relationShip
         })
         

--- a/DocX/DocXWriting.swift
+++ b/DocX/DocXWriting.swift
@@ -18,12 +18,16 @@ import AppKit
 @available(OSX 10.11, *)
 extension DocX where Self : NSAttributedString{
     
-    var pageDef:AEXMLElement{
+    func pageDef(options: DocXOptions?) -> AEXMLElement{
         let pageDef=AEXMLElement(name: "w:sectPr", value: nil, attributes: ["w:rsidR":"00045791", "w:rsidSect":"004F37A0"])
         
         if self.usesVerticalForms{
             let vertical=AEXMLElement(name: "w:textDirection", value: nil, attributes: ["w:val":"tbRl"])
             pageDef.addChild(vertical)
+        }
+        
+        if let page=options?.pageDefinition{
+            pageDef.addChildren(page.pageElements)
         }
         
         //these elements are added for by word, but not by the cocoa docx exporter. word then falls back to the page setup defined by the print settings of the machine. this seems useful
@@ -72,7 +76,7 @@ extension DocX where Self : NSAttributedString{
         body.addChildren(self.buildParagraphs(paragraphRanges: self.paragraphRanges,
                                               linkRelations: linkRelations,
                                               options: options))
-        body.addChild(pageDef)
+        body.addChild(pageDef(options: options))
         return document.xmlCompact
     }
     

--- a/DocX/ImageRelationship.swift
+++ b/DocX/ImageRelationship.swift
@@ -19,6 +19,9 @@ struct ImageRelationship: DocumentRelationship{
     let relationshipID:String
     let linkURL:URL
     let attachement:NSTextAttachment
+    let pageDefinition:PageDefinition?
+    
+    
 }
 
 extension ImageRelationship{
@@ -97,7 +100,9 @@ extension ImageRelationship{
         let frameProperties=AEXMLElement(name: "wp:cNvGraphicFramePr")
         frameProperties.addChild(AEXMLElement(name: "a:graphicFrameLocks", value: nil, attributes: ["xmlns:a":"http://schemas.openxmlformats.org/drawingml/2006/main", "noChangeAspect":"1"]))
         
-        inline.addChildren(attachement.extentAttributes + [docPr, frameProperties, graphic])
+        let extentAttributes=attachement.extentAttribute(pageSize: pageDefinition)
+        
+        inline.addChildren(extentAttributes + [docPr, frameProperties, graphic])
         
         let graphicData=AEXMLElement(name: "a:graphicData", value: nil, attributes: ["uri":"http://schemas.openxmlformats.org/drawingml/2006/picture"])
         
@@ -126,7 +131,8 @@ extension ImageRelationship{
         pic.addChild(shapeProperties)
         let xFrame=AEXMLElement(name: "a:xfrm")
         xFrame.addChild(AEXMLElement(name: "a:off", value: nil, attributes: ["x":"0","y":"0"]))
-        let extent=AEXMLElement(name: "a:ext", value: nil, attributes: self.attachement.extentInEMU.extentAttributes)
+        let extentInEmu=attachement.extentInEMU(pageSize: pageDefinition)
+        let extent=AEXMLElement(name: "a:ext", value: nil, attributes: extentInEmu.extentAttributes)
         xFrame.addChild(extent)
         shapeProperties.addChild(xFrame)
         

--- a/DocX/NSAttributedString+DocX-macOS.swift
+++ b/DocX/NSAttributedString+DocX-macOS.swift
@@ -56,7 +56,7 @@ extension NSAttributedString{
             options.escape = true
 
             let linkDocument=try AEXMLDocument(xml: linkData, options: options)
-            let linkRelations=self.prepareLinks(linkXML: linkDocument, mediaURL: mediaURL)
+            let linkRelations=self.prepareLinks(linkXML: linkDocument, mediaURL: mediaURL, options: DocXOptions())
             let updatedLinks=linkDocument.xmlCompact
             try updatedLinks.write(to: linkURL, atomically: true, encoding: .utf8)
             

--- a/DocX/NSAttributedString+Writing.swift
+++ b/DocX/NSAttributedString+Writing.swift
@@ -67,7 +67,7 @@ extension NSAttributedString{
             linkDocument.root.addChild(name: "Relationship", value: nil, attributes: attrs)
         }
         
-        let linkRelations=self.prepareLinks(linkXML: linkDocument, mediaURL: mediaURL)
+        let linkRelations=self.prepareLinks(linkXML: linkDocument, mediaURL: mediaURL, options: options)
         let updatedLinks=linkDocument.xmlCompact
         try updatedLinks.write(to: linkURL, atomically: true, encoding: .utf8)
         

--- a/DocX/NSTextAttachement+Extensions.swift
+++ b/DocX/NSTextAttachement+Extensions.swift
@@ -68,7 +68,7 @@ extension NSTextAttachment{
         }
     }
     
-    var extentInEMU:Size{
+    func extentInEMU(pageSize:PageDefinition?) -> Size{
         let size:CGSize
         if self.bounds != .zero{
             size=self.bounds.size
@@ -77,8 +77,23 @@ extension NSTextAttachment{
             size=self.dataImageSize
         }
         
-        let width=size.width
-        let height=size.height
+        let width:CGFloat
+        let height:CGFloat
+        
+        
+        // we have a page size defined and the image is larger (in one dimension) than the page. we shrink the image to fit the printable area of the page.
+        if let bounds=pageSize?.printableSize(unit: .points),
+            (bounds.height < size.height || bounds.width < size.width) {
+            let ratio=min(bounds.height / size.height, bounds.width / size.width)
+            let scaledSize=size.applying(.init(scaleX: ratio, y: ratio))
+            width=scaledSize.width
+            height=scaledSize.height
+        }
+        else{
+            width=size.width
+            height=size.height
+        }
+        
 
         let emuPerInch=CGFloat(914400)
         let dpi=CGFloat(72)
@@ -88,8 +103,8 @@ extension NSTextAttachment{
         
     }
     
-    var extentAttributes:[AEXMLElement]{
-        let size=self.extentInEMU
+    func extentAttribute(pageSize:PageDefinition?) -> [AEXMLElement]{
+        let size=self.extentInEMU(pageSize: pageSize)
         let extent=size.extentAttribute
         let effectiveExtent=AEXMLElement(name: "wp:effectExtent", value: nil, attributes: ["l":"0", "t":"0","r":"0","b":"0"])
         return [extent,effectiveExtent]

--- a/DocXTests/DocXTests.swift
+++ b/DocXTests/DocXTests.swift
@@ -790,6 +790,31 @@ let string = """
     }
     
     
+    func testScaleImageToSize() throws{
+        let loremIpsum = """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        """
+        
+        let imageURL=try XCTUnwrap(bundle.url(forResource: "lenna", withExtension: "png"), "ImageURL not found")
+        let imageData=try XCTUnwrap(Data(contentsOf: imageURL), "Image not found")
+        let attachement=NSTextAttachment(data: imageData, ofType: kUTTypePNG as String)
+        
+        let text=NSMutableAttributedString()
+        text.append(NSAttributedString(string: loremIpsum, attributes: [.foregroundColor: NSColor.red]))
+        text.append(NSAttributedString(string: "\r"))
+        text.append(NSAttributedString(attachment: attachement))
+        text.append(NSAttributedString(string: loremIpsum, attributes: [.foregroundColor: NSColor.black, .font: NSFont(name: "Helvetica", size: 19)!]))
+        
+        let defs = [PageDefinition(pageSize: .A4)]
+        
+        for def in defs{
+            var options=DocXOptions()
+            options.pageDefinition=def
+            try writeAndValidateDocX(attributedString: text, options: options)
+        }
+        
+    }
+    
     // MARK: Performance Tests
     
     func testPerformanceLongBook() {

--- a/DocXTests/DocXTests.swift
+++ b/DocXTests/DocXTests.swift
@@ -755,6 +755,40 @@ let string = """
         
     }
     
+    func testPageSize() throws{
+        let loremIpsum = """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        """
+        
+        func makeText(howMany:Int)->NSMutableAttributedString{
+            let text=NSMutableAttributedString()
+            
+            for _ in 0...howMany{
+                text.append(NSAttributedString(string: loremIpsum))
+                text.append(NSAttributedString(string: "\r\r"))
+            }
+            return text
+        }
+        
+        
+        let defs = [PageDefinition(pageSize: .A4),
+                    PageDefinition(pageSize: .letter),
+                    PageDefinition(pageSize: .A4, pageMargins: .init(edgeInsets: NSEdgeInsets(top: 500, left: 100, bottom: 50, right: 40))),
+                    PageDefinition(pageSize: .init(width: Measurement(value: 10, unit: .centimeters), height: Measurement(value: 10, unit: .centimeters))),
+                    PageDefinition(pageSize: .init(width: Measurement(value: 10, unit: .inches), height: Measurement(value: 10, unit: .centimeters)), pageMargins: PageDefinition.PageMargins(top: Measurement(value: 1, unit: .centimeters), bottom: Measurement(value: 25, unit: .millimeters), left: .init(value: 1, unit: .inches), right: .init(value: 50, unit: .points)))]
+        
+        for def in defs{
+            var options=DocXOptions()
+            options.pageDefinition=def
+            
+            let text=makeText(howMany: 20)
+            text.insert(NSAttributedString(string: "\(def.description)\r\r", attributes: [.foregroundColor: NSColor.red]), at: 0)
+            try writeAndValidateDocX(attributedString: text, options: options)
+        }
+        
+        
+    }
+    
     
     // MARK: Performance Tests
     


### PR DESCRIPTION
This PR implements image autosizing if a custom page size is defined and the image is larger than the printable area of the page. In this case, the image is shrunk to fit the printable area. 
Issues with the current implementation:
 - custom sizing of the `NSTextAttachement`  (`NSTextAttachement.bounds`) is overridden if it is larger than th printable area. This might be surprising. 
 - The size of the test image (`Jenna.png`) in Word is only half the expected size when inserted via copy / paste into Word or if automatic sizing (no page size or bounds defined in `DocX`) are used. It is not entirely clear when default values Word is using for autosizing.