### PR TITLE
Fixed underlining when no explicit foreground color is set

### DIFF
--- a/DocX/AttributeElements.swift
+++ b/DocX/AttributeElements.swift
@@ -41,13 +41,11 @@ extension Dictionary where Key == NSAttributedString.Key{
         }
         
         if let style=self[.underlineStyle] as? Int {
-            let foregroundColor = self[.foregroundColor] as? NSColor
+            // If the `underlineColor` attribute is present, use that as the color
             let underlineColor = self[.underlineColor] as? NSColor
-            // If the `underlineColor` attribute is present, prefer that to the
-            // `foregroundColor` (if any)
-            let color = underlineColor ?? foregroundColor
+            
             let underline=NSUnderlineStyle(rawValue: style)
-            attributesElement.addChild(underline.underlineElement(for: color))
+            attributesElement.addChild(underline.underlineElement(for: underlineColor))
         }
         
         if let backgroundColor=self[.backgroundColor] as? NSColor{

--- a/DocX/AttributeElements.swift
+++ b/DocX/AttributeElements.swift
@@ -40,7 +40,12 @@ extension Dictionary where Key == NSAttributedString.Key{
             attributesElement.addChildren(self.outlineProperties(strokeWidth: strokeWidth, font:font))
         }
         
-        if let style=self[.underlineStyle] as? Int, let color=self[.foregroundColor] as? NSColor{
+        if let style=self[.underlineStyle] as? Int {
+            let foregroundColor = self[.foregroundColor] as? NSColor
+            let underlineColor = self[.underlineColor] as? NSColor
+            // If the `underlineColor` attribute is present, prefer that to the
+            // `foregroundColor` (if any)
+            let color = underlineColor ?? foregroundColor
             let underline=NSUnderlineStyle(rawValue: style)
             attributesElement.addChild(underline.underlineElement(for: color))
         }

--- a/DocX/NSUnderlineStyle+Elements.swift
+++ b/DocX/NSUnderlineStyle+Elements.swift
@@ -41,9 +41,17 @@ extension NSUnderlineStyle{
         return val
     }
     
-    func underlineElement(for color:NSColor)->AEXMLElement{
-        let colorString=color.hexColorString
-        return AEXMLElement(name: "w:u", value: nil, attributes: ["w:color":colorString, "w:val":self.elementValue])
+    func underlineElement(for color:NSColor?)->AEXMLElement{
+        // Always add the underline value, which determines the underline style
+        var attributes = ["w:val": self.elementValue]
+        
+        // If color is specified, include that too
+        if let color = color {
+            let colorString = color.hexColorString
+            attributes["w:color"] = colorString
+        }
+        
+        return AEXMLElement(name: "w:u", value: nil, attributes: attributes)
     }
     
     var strikeThroughElement:AEXMLElement{


### PR DESCRIPTION
The `color` argument to `underlineElement` is now optional, since the OOXML `<w:u>` element doesn't require it. If the `underlineColor` NSAttributedString.Key is set, that will be passed. Otherwise, when nil is passed, no color will be explicitly set. Happily, in that case, Word just uses the text color anyways.